### PR TITLE
Missing quotation mark based on below error

### DIFF
--- a/eventbridge/template.yaml
+++ b/eventbridge/template.yaml
@@ -78,6 +78,6 @@ Outputs:
     Description: "HTTP API endpoint URL"
     Value: !Sub "https://${ServerlessHttpApi}.execute-api.${AWS::Region}.amazonaws.com"
   MyNotificationArn:
-    Description: Topic ARN"
+    Description: "Topic ARN"
     Value: !Ref AWS::NotificationARNs
 


### PR DESCRIPTION
Waiting for changeset to be created..
Error: Failed to create changeset for the stack: foo-sessions-sam-eventbridge-example, ex: Waiter ChangeSetCreateComplete failed: Waiter encountered a terminal failure state Status: FAILED. Reason: Template format error: The Value field of every Outputs member must evaluate to a String.

***Still getting error.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
