### PR TITLE
Added appconfig-lambda-extensions

### DIFF
--- a/appconfig-lambda-extensions/README.md
+++ b/appconfig-lambda-extensions/README.md
@@ -1,0 +1,86 @@
+# Using AWS AppConfig with AWS Lambda Extensions
+
+## Description
+
+This is an example of how [AWS AppConfig](https://docs.aws.amazon.com/appconfig/latest/userguide/what-is-appconfig.html) can be used with [AWS Lambda](https://aws.amazon.com/lambda/) and [Lambda Extensions](https://aws.amazon.com/blogs/compute/introducing-aws-lambda-extensions-in-preview/). Using AppConfig to separate your application configuration from your application code is good practice. By using that, you are able to deploy configuration changes independently from your code. AWS AppConfig helps us achieve that.
+
+This example will deploy a sample serverless applications with AWS AppConfig and the AppConfig Lambda layer needed for AWS Lambda Extensions using AWS SAM. These are the resources being deployed:
+
+* Lambda Function
+* Lambda IAM Role
+* Lambda Permissions for AppConfig
+* HTTP API
+* AppConfig Application
+* AppConfig Environment
+* AppConfig Deployment Strategy
+* AppConfig Configuration Profile
+* AppConfig Hosted Configuration Version
+* AppConfig Deployment
+
+## How to install using AWS SAM
+
+1. Install [AWS SAM CLI](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-install.html).
+2. Build using AWS SAM CLI.
+```bash
+sam build
+```
+3. Deploy using AWS SAM CLI and follow prompts.
+```bash
+sam deploy --guided
+```
+4. Use HTTP API endpoint from SAM CLI output to test application. If successfully deployed, you should get the following message.
+```bash
+"Hello from Lambda!"
+```
+
+## How to use after deployment
+
+1. Open AppConfig in the AWS Console and browse to the hosted configuration for the deployed application. Link available in the output of SAM CLI after deployment.
+2. Click "Create" and update the content with new configuration. Save by clicking "Create hosted configuration version".
+```json
+{
+  "isEnabled": true,
+  "messageOption": "AppConfig"
+}
+```
+3. Click "Start deployment" and select the environment, the latest version of the hosted configuration, and the deployment strategy. Press "Start deployment" to start the deployment of the new configuration version.
+4. If validation of the updated configuration passes, you will be sent to the status page of the deployment.
+5. Test the new configuration by using the HTTP API endpoint from SAM CLI output. Remember that the AWS AppConfig extension uses caching that is configureable in the SAM template.
+```bash
+"Hello from AppConfig!"
+```
+
+
+## Notes
+
+* The initial configuration is deployed using the AppConfigLambdaConfigurationVersion resource in template.yaml.
+```yaml
+AppConfigLambdaConfigurationVersion:
+  Type: AWS::AppConfig::HostedConfigurationVersion
+  Properties:
+    ApplicationId: !Ref AppConfigLambdaApplication
+    ConfigurationProfileId: !Ref AppConfigLambdaConfigurationProfile
+    Content: '{ "isEnabled": false, "messageOption": "AppConfig" }'
+    ContentType: 'application/json'
+```
+* The validation schema is deployed using the AppConfigLambdaConfigurationProfile resource in template.yaml.
+```yaml
+AppConfigLambdaConfigurationProfile:
+  Type: 'AWS::AppConfig::ConfigurationProfile'
+  Properties:
+    Name: AppConfigLambda
+    ApplicationId: !Ref AppConfigLambdaApplication
+    LocationUri: hosted
+    Validators:
+      - Content: '{ "$schema": "http://json-schema.org/draft-04/schema#", "type": "object", "properties": { "isEnabled": { "type": "boolean" }, "messageOption": { "type": "string", "minimum": 0 } }, "required": ["isEnabled", "messageOption"] }'
+        Type: JSON_SCHEMA
+```
+* The caching and timeout behavior of AppConfig can be changed by uncommenting and changing the values in template.yaml.
+```yaml
+# AWS_APPCONFIG_EXTENSION_POLL_INTERVAL_SECONDS: 45
+# AWS_APPCONFIG_EXTENSION_POLL_TIMEOUT_MILLIS: 3000
+```
+
+## Contributors
+
+**Gunnar Grosch** - [GitHub](https://github.com/gunnargrosch) | [Twitter](https://twitter.com/gunnargrosch) | [LinkedIn](https://www.linkedin.com/in/gunnargrosch/)

--- a/appconfig-lambda-extensions/src/app.js
+++ b/appconfig-lambda-extensions/src/app.js
@@ -1,0 +1,42 @@
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this
+// software and associated documentation files (the "Software"), to deal in the Software
+// without restriction, including without limitation the rights to use, copy, modify,
+// merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so.
+// //
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+// PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+// SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+'use strict'
+const fetch = require('node-fetch')
+let message
+
+async function getConfig () {
+  try {
+    const url = 'http://localhost:2772/applications/' + process.env.APPCONFIG_APPLICATION + '/environments/' + process.env.APPCONFIG_ENVIRONMENT + '/configurations/' + process.env.APPCONFIG_CONFIGURATION
+    const response = await fetch(url)
+    const json = await response.json()
+    return json
+  } catch (err) {
+    console.error(err)
+    throw err
+  }
+}
+
+exports.handler = async (event) => {
+  const options =  await getConfig()
+  if (options.isEnabled === true) {
+    message = 'Hello from ' + options.messageOption + '!'
+  } else {
+    message = 'Hello from Lambda!'
+  }
+  const response = {
+      statusCode: 200,
+      body: JSON.stringify(message),
+  };
+  return response;
+};

--- a/appconfig-lambda-extensions/src/package-lock.json
+++ b/appconfig-lambda-extensions/src/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "appconfig-lambda-extensions",
+  "version": "0.0.1",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "node-fetch": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
+    }
+  }
+}

--- a/appconfig-lambda-extensions/src/package.json
+++ b/appconfig-lambda-extensions/src/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "appconfig-lambda-extensions",
+  "version": "0.0.1",
+  "description": "",
+  "dependencies": {
+    "node-fetch": "^2.6.1"
+  }
+}

--- a/appconfig-lambda-extensions/template.yaml
+++ b/appconfig-lambda-extensions/template.yaml
@@ -1,0 +1,166 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Description: Using AWS AppConfig with AWS Lambda Extensions
+
+Parameters:
+  AppName:
+    Type: String
+    Description: Name of the application
+    Default: 'AppConfigLambda'
+
+Globals:
+  Function:
+    Timeout: 3
+
+Resources:
+  AppConfigLambdaFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: 
+      Handler: app.handler
+      Runtime: nodejs12.x
+      CodeUri: src/
+      Layers:
+          - !FindInMap [AppConfigLayer, !Ref "AWS::Region", ARN]
+      Policies:
+        - Version: '2012-10-17'
+          Statement:
+            - Effect: Allow
+              Action:
+                - appconfig:GetConfiguration
+              Resource:
+                - Fn::Join:
+                  - ''
+                  - - 'arn:aws:appconfig:*:*:application/'
+                    - Ref: AppConfigLambdaApplication
+                - Fn::Join:
+                  - ''
+                  - - 'arn:aws:appconfig:*:*:application/'
+                    - Ref: AppConfigLambdaApplication
+                    - '/configurationprofile/'
+                    - Ref: AppConfigLambdaConfigurationProfile
+                - Fn::Join:
+                  - ''
+                  - - 'arn:aws:appconfig:*:*:application/'
+                    - Ref: AppConfigLambdaApplication
+                    - '/environment/'
+                    - Ref: AppConfigLambdaEnvironment
+      Environment:
+        Variables:
+          APPCONFIG_APPLICATION: !Ref AppConfigLambdaApplication
+          APPCONFIG_ENVIRONMENT: !Ref AppConfigLambdaEnvironment
+          APPCONFIG_CONFIGURATION: !Ref AppConfigLambdaConfigurationProfile
+      #     AWS_APPCONFIG_EXTENSION_POLL_INTERVAL_SECONDS: 45
+      #     AWS_APPCONFIG_EXTENSION_POLL_TIMEOUT_MILLIS: 3000
+      #     AWS_APPCONFIG_EXTENSION_HTTP_PORT: 2772
+      Events:
+        AppConfigLambda:
+          Type: HttpApi
+          Properties:
+            ApiId: !Ref HttpApi
+            Path: /
+            Method: GET
+  HttpApi:
+    Type: AWS::Serverless::HttpApi
+    Properties:
+      FailOnWarnings: True
+  AppConfigLambdaApplication:
+    Type: 'AWS::AppConfig::Application'
+    Properties:
+      Name: !Ref AppName
+  AppConfigLambdaEnvironment:
+    Type: 'AWS::AppConfig::Environment'
+    Properties:
+      Name: !Ref AppName
+      ApplicationId: !Ref AppConfigLambdaApplication
+  AppConfigLambdaConfigurationProfile:
+    Type: 'AWS::AppConfig::ConfigurationProfile'
+    Properties:
+      Name: !Ref AppName
+      ApplicationId: !Ref AppConfigLambdaApplication
+      LocationUri: hosted
+      Validators:
+        - Content: '{ "$schema": "http://json-schema.org/draft-04/schema#", "type": "object", "properties": { "isEnabled": { "type": "boolean" }, "messageOption": { "type": "string", "minimum": 0 } }, "required": ["isEnabled", "messageOption"] }'
+          Type: JSON_SCHEMA
+  AppConfigLambdaConfigurationVersion:
+    Type: AWS::AppConfig::HostedConfigurationVersion
+    Properties:
+      ApplicationId: !Ref AppConfigLambdaApplication
+      ConfigurationProfileId: !Ref AppConfigLambdaConfigurationProfile
+      Content: '{ "isEnabled": false, "messageOption": "AppConfig" }'
+      ContentType: 'application/json'
+  AppConfigLambdaDeploymentStrategy:
+    Type: AWS::AppConfig::DeploymentStrategy
+    Properties: 
+      Name: !Ref AppName
+      DeploymentDurationInMinutes: 0
+      FinalBakeTimeInMinutes: 0
+      GrowthFactor: 100
+      GrowthType: LINEAR
+      ReplicateTo: NONE
+  AppConfigLambdaDeployment:
+    Type: AWS::AppConfig::Deployment
+    Properties: 
+      ApplicationId: !Ref AppConfigLambdaApplication
+      ConfigurationProfileId: !Ref AppConfigLambdaConfigurationProfile
+      ConfigurationVersion: !Ref AppConfigLambdaConfigurationVersion
+      DeploymentStrategyId: !Ref AppConfigLambdaDeploymentStrategy
+      EnvironmentId: !Ref AppConfigLambdaEnvironment
+
+Mappings:
+  AppConfigLayer: 
+    us-east-1:
+      ARN: arn:aws:lambda:us-east-1:027255383542:layer:AWS-AppConfig-Extension:1
+    us-east-2:
+      ARN: arn:aws:lambda:us-east-2:728743619870:layer:AWS-AppConfig-Extension:1
+    us-west-1:
+      ARN: arn:aws:lambda:us-west-1:958113053741:layer:AWS-AppConfig-Extension:1
+    us-west-2:
+      ARN: arn:aws:lambda:us-west-2:359756378197:layer:AWS-AppConfig-Extension:1
+    ca-central-1:
+      ARN: arn:aws:lambda:ca-central-1:039592058896:layer:AWS-AppConfig-Extension:1
+    eu-central-1:
+      ARN: arn:aws:lambda:eu-central-1:066940009817:layer:AWS-AppConfig-Extension:1
+    eu-west-1:
+      ARN: arn:aws:lambda:eu-west-1:434848589818:layer:AWS-AppConfig-Extension:1
+    eu-west-2:
+      ARN: arn:aws:lambda:eu-west-2:282860088358:layer:AWS-AppConfig-Extension:1
+    eu-west-3:
+      ARN: arn:aws:lambda:eu-west-3:493207061005:layer:AWS-AppConfig-Extension:1
+    eu-north-1:
+      ARN: arn:aws:lambda:eu-north-1:646970417810:layer:AWS-AppConfig-Extension:1
+    eu-south-1:
+      ARN: arn:aws:lambda:eu-south-1:203683718741:layer:AWS-AppConfig-Extension:1
+    ap-east-1:
+      ARN: arn:aws:lambda:ap-east-1:630222743974:layer:AWS-AppConfig-Extension:1
+    ap-northeast-1:
+      ARN: arn:aws:lambda:ap-northeast-1:980059726660:layer:AWS-AppConfig-Extension:1
+    ap-northeast-2:
+      ARN: arn:aws:lambda:ap-northeast-2:826293736237:layer:AWS-AppConfig-Extension:1
+    ap-southeast-1:
+      ARN: arn:aws:lambda:ap-southeast-1:421114256042:layer:AWS-AppConfig-Extension:1
+    ap-southeast-2:
+      ARN: arn:aws:lambda:ap-southeast-2:080788657173:layer:AWS-AppConfig-Extension:1
+    ap-south-1:
+      ARN: arn:aws:lambda:ap-south-1:554480029851:layer:AWS-AppConfig-Extension:1
+    sa-east-1:
+      ARN: arn:aws:lambda:sa-east-1:000010852771:layer:AWS-AppConfig-Extension:1
+    af-south-1:
+      ARN: arn:aws:lambda:af-south-1:574348263942:layer:AWS-AppConfig-Extension:1
+    me-south-1:
+      ARN: arn:aws:lambda:me-south-1:559955524753:layer:AWS-AppConfig-Extension:1
+
+Outputs:
+  HttpApiUrl:
+    Description: URL of your API endpoint
+    Value:
+      Fn::Sub: 'https://${HttpApi}.execute-api.${AWS::Region}.${AWS::URLSuffix}/'
+  AppConfigUrl:
+    Description: URL to your application in AppConfig
+    Value:
+      Fn::Sub: 'https://${AWS::Region}.console.aws.amazon.com/systems-manager/appconfig/applications/${AppConfigLambdaApplication}/'
+  AppConfigHostedConfigurationUrl:
+    Description: URL to your hosted configuration in AppConfig
+    Value:
+      Fn::Sub: 'https://${AWS::Region}.console.aws.amazon.com/systems-manager/appconfig/applications/${AppConfigLambdaApplication}/configurationprofiles/${AppConfigLambdaConfigurationProfile}/versions'
+      


### PR DESCRIPTION
*Description of changes:*
Added an example of how AWS AppConfig can be used with AWS Lambda and Lambda Extensions.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
