### PR TITLE
Change Handler Property value to avoid confusion

### DIFF
--- a/go-al2/template.yaml
+++ b/go-al2/template.yaml
@@ -15,7 +15,7 @@ Resources:
     Type: AWS::Serverless::Function # More info about Function Resource: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessfunction
     Properties:
       CodeUri: hello-world/
-      Handler: my.bootstrap.file
+      Handler: bootstrap 
       Runtime: provided.al2
       Tracing: Active # https://docs.aws.amazon.com/lambda/latest/dg/lambda-x-ray.html
       Events:


### PR DESCRIPTION
As the old value my.bootstrap.file is not referenced anywhere, this can cause confusion as the meaning of this value
Reference: https://docs.aws.amazon.com/lambda/latest/dg/runtimes-custom.html#runtimes-custom-build

*Description of changes:*

Just renamed the value of Handler property inside the template.yaml to help users to follow the flow of the different settings


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
