### PR TITLE
Fix typo in comment

### DIFF
--- a/custom-domains/http/template.yaml
+++ b/custom-domains/http/template.yaml
@@ -35,7 +35,7 @@ Resources:
       DomainName: !Ref DomainName
       ValidationMethod: DNS
 
-  HttpApiGateway: # Creates a HTTP API endpoint under the customm domian
+  HttpApiGateway: # Creates a HTTP API endpoint under the customm domain
     Type: AWS::Serverless::HttpApi
     Properties:
       Domain:


### PR DESCRIPTION
*Description of changes:* Fix typo. `domian` should be `domain`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
