### PR TITLE
fix: typo in AccessLogSettings Format JSON

### DIFF
--- a/http-api-logging/template.yaml
+++ b/http-api-logging/template.yaml
@@ -12,7 +12,7 @@ Resources:
     Properties:
       AccessLogSettings:
         DestinationArn: !GetAtt MyLogGroup.Arn
-        Format: '{ "requestId":"$context.requestId", "ip": "$context.identity.sourceIp", "requestTime":"$context.requestTime", "httpMethod":"$context.httpMethod","routeKey":"$context.routeKey", "status":"$context.status","protocol":"$context.protocol", "responseLength":"$context.responseLength", "integrationError:"$context.integrationErrorMessage" }'
+        Format: '{ "requestId":"$context.requestId", "ip": "$context.identity.sourceIp", "requestTime":"$context.requestTime", "httpMethod":"$context.httpMethod","routeKey":"$context.routeKey", "status":"$context.status","protocol":"$context.protocol", "responseLength":"$context.responseLength", "integrationError":"$context.integrationErrorMessage" }'
       CorsConfiguration:
         AllowMethods:
           - GET


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

As noticed by @efx in https://github.com/aws/serverless-application-model/issues/2150, there is a typo in the `Format` JSON. This fixes it.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
