### PR TITLE
Fix serverless go example

### DIFF
--- a/go-al2/README.md
+++ b/go-al2/README.md
@@ -25,6 +25,12 @@ This is a sample template for Go on Amazon Linux 2 (AL2) - Below is a brief expl
 
 ### Installing dependencies & building the target
 
+Init a go module to create go.mod
+
+```shell
+go mod init hello-world
+```
+
 Install the go lambda module
 
 ```shell

--- a/go-al2/hello-world/Makefile
+++ b/go-al2/hello-world/Makefile
@@ -1,3 +1,3 @@
 build-HelloWorldFunction:
-	GOOS=linux go build -o bootstrap
+	GOOS=linux CGO_ENABLED=0 go build -o bootstrap
 	cp ./bootstrap $(ARTIFACTS_DIR)/.


### PR DESCRIPTION
Fixes issue #4

and also an error which I faced trying to start it locally.
```
/var/task/bootstrap: /lib64/libc.so.6: version `GLIBC_2.34' not found (required by /var/task/bootstrap)
```

*Description of changes:*

I've added a step to call `go init module` to create `go.mod` required in following steps. I've also added CGO_ENABLED=0 flag to build staticaly-linked app. Alternatively I can add it to the troubleshooting section in the readme file instead.

Thanks!